### PR TITLE
Refactor Game to use group-based object management instead of dict

### DIFF
--- a/src/lib/game/event/__init__.py
+++ b/src/lib/game/event/__init__.py
@@ -1,3 +1,3 @@
 from src.lib.game.event.event import Event, EventStage
-from src.lib.game.event.misc import AddPlayer, GameEnd, GameStart
+from src.lib.game.event.misc import AddAsset, AddPlayer, GameEnd, GameStart
 from src.lib.game.event.speech import Interrupt, Speech

--- a/src/lib/game/event/misc.py
+++ b/src/lib/game/event/misc.py
@@ -12,3 +12,7 @@ class GameEnd(Event):
 
 class AddPlayer(Event):
     player_lid: Lid
+
+
+class AddAsset(Event):
+    asset_lid: Lid

--- a/src/lib/game/game.py
+++ b/src/lib/game/game.py
@@ -27,10 +27,13 @@ class Game(Logger):
     logspace_part = "game"
 
     class _gona(StrEnum):
+        ALL = "all"
         ALL_PLAYERS = "all_players"
+        ALL_ASSETS = "all_assets"
 
-    # Mapping from player's lid to player object
-    players: dict[Lid, Player]
+    # Strong references to owned Logger objects to prevent GC.
+    # Access to objects should go through groups + env.loggers, not this set.
+    _owned: set
 
     # The game state contains all static dataclass about the game
     # It should only be accessed via state(), not directly
@@ -46,8 +49,12 @@ class Game(Logger):
         **kwargs,
     ):
         super().__init__(*args, logname=logname, **kwargs)
-        self.players = dict()
+        self._owned = set()
         self._state_lock = asyncio.Lock()
+
+        # Set up group nesting: ALL -> {ALL_PLAYERS, ALL_ASSETS}
+        group.add(self.gid(self.gona.ALL), self.gid(self.gona.ALL_PLAYERS))
+        group.add(self.gid(self.gona.ALL), self.gid(self.gona.ALL_ASSETS))
         self._state = GameState(
             max_react_per_event=params.max_react_per_event,
             max_successive_interrupt=params.max_successive_interrupt,
@@ -165,19 +172,24 @@ class Game(Logger):
                 < state.max_successive_interrupt
             )
 
-        # Send notif
+        # Send notif to players (only Players can ack events)
         viewer_lids = group.deslid(e.vis)
-        tasks = [
-            self.players[viewer_lid].ack_event(
-                e, can_react=can_react, can_interrupt=can_interrupt
-            )
-            for viewer_lid in viewer_lids
-        ]
+        tasks = []
+        player_lids = []
+        for lid in viewer_lids:
+            obj = env.loggers.get(lid)
+            if isinstance(obj, Player):
+                tasks.append(
+                    obj.ack_event(
+                        e, can_react=can_react, can_interrupt=can_interrupt
+                    )
+                )
+                player_lids.append(lid)
         react_lists = await asyncio.gather(*tasks)
 
         # Filter out wrong reacts
         filtered_reacts = []
-        for viewer_lid, react_list in zip(viewer_lids, react_lists):
+        for viewer_lid, react_list in zip(player_lids, react_lists):
             filtered = []
             for react in react_list:
                 if not can_react:
@@ -196,7 +208,7 @@ class Game(Logger):
                 filtered.append(react)
             filtered_reacts.append(filtered)
 
-        viewer2reacts = dict(zip(viewer_lids, filtered_reacts))
+        viewer2reacts = dict(zip(player_lids, filtered_reacts))
         return viewer2reacts
 
     async def _process_reacts(
@@ -238,10 +250,7 @@ class Game(Logger):
     # HANDLER FUNCS ############################################################
 
     async def _handle_AddPlayer(self, e: AddPlayer):
-        player = env.loggers[e.player_lid]
-        self.players[player.lid] = player
-        group.add(self.gid(self.gona.ALL_PLAYERS), player.lid)
-        self.info(f"Added player: {player.lid}")
+        self._add_player(e.player_lid)
 
     async def _handle_GameStart(self, _: GameStart):
         async with self.state() as state:
@@ -252,6 +261,22 @@ class Game(Logger):
         async with self.state() as state:
             state.stage = GameStage.ENDED
         self.info("Game ending")
+
+    # ONBOARDING HELPERS #######################################################
+
+    def _add_player(self, lid: Lid):
+        """Register a player: hold strong ref and add to ALL_PLAYERS group."""
+        player = env.loggers[lid]
+        self._owned.add(player)
+        group.add(self.gid(self.gona.ALL_PLAYERS), lid)
+        self.info(f"Added player: {lid}")
+
+    def _add_asset(self, lid: Lid):
+        """Register an asset: hold strong ref and add to ALL_ASSETS group."""
+        asset = env.loggers[lid]
+        self._owned.add(asset)
+        group.add(self.gid(self.gona.ALL_ASSETS), lid)
+        self.info(f"Added asset: {lid}")
 
     # UTILS ####################################################################
 

--- a/test/lib/game/test_game_features.py
+++ b/test/lib/game/test_game_features.py
@@ -26,10 +26,8 @@ async def test_add_player_immediate():
     # When WAITING, add_player should process the event immediately
     await game.add_player(player1)
 
-    assert player1.lid in game.players
-    # Check if added to 'all' group
-    all_members = group.children(game.gid(game.gona.ALL_PLAYERS))
-    assert player1.lid in all_members
+    # Check if added to ALL_PLAYERS group
+    assert player1.lid in group.children(game.gid(game.gona.ALL_PLAYERS))
 
 
 @pytest.mark.asyncio
@@ -47,8 +45,8 @@ async def test_add_player_queued():
     # When ONGOING, add_player should only enqueue the event
     await game.add_player(player1)
 
-    # Should NOT be in players yet
-    assert player1.lid not in game.players
+    # Should NOT be in ALL_PLAYERS group yet
+    assert player1.lid not in group.children(game.gid(game.gona.ALL_PLAYERS))
 
     # Check event queue
     async with game.state() as state:
@@ -61,7 +59,6 @@ async def test_add_player_queued():
     e = await game._pop_event()
     await game._process_event(e)
 
-    assert player1.lid in game.players
     assert player1.lid in group.children(game.gid(game.gona.ALL_PLAYERS))
 
 
@@ -83,3 +80,22 @@ async def test_arbitrary_grouping():
     # Remove from group
     group.rm(team_gid, player.lid)
     assert player.lid not in group.children(team_gid)
+
+
+@pytest.mark.asyncio
+async def test_all_group_nesting():
+    """Test that ALL group contains ALL_PLAYERS and ALL_ASSETS as sub-groups."""
+    params = GameInitParams()
+    game = Game(params=params, logname="test_game_nesting")
+
+    # ALL should contain ALL_PLAYERS and ALL_ASSETS as children
+    all_children = group.children(game.gid(game.gona.ALL))
+    assert game.gid(game.gona.ALL_PLAYERS) in all_children
+    assert game.gid(game.gona.ALL_ASSETS) in all_children
+
+    # Add a player and verify resolvable from ALL
+    player = DummyPlayer(logname="p4")
+    await game.add_player(player)
+
+    all_descendants = group.descendants(game.gid(game.gona.ALL))
+    assert player.lid in all_descendants


### PR DESCRIPTION
## Summary
Refactored the Game class to use a group-based architecture for managing players and assets instead of maintaining a direct dictionary. This change improves extensibility and provides a unified interface for managing different types of game objects.

## Key Changes

- **Replaced `players` dict with `_owned` set**: Changed from `players: dict[Lid, Player]` to `_owned: set` to hold strong references to owned Logger objects, preventing garbage collection while allowing flexible object types.

- **Introduced group hierarchy**: Added a new `ALL` group that nests `ALL_PLAYERS` and `ALL_ASSETS` as sub-groups, enabling hierarchical organization of game objects.

- **Updated player lookup logic**: Modified `_send_notif()` to look up players via `env.loggers.get(lid)` with type checking instead of direct dictionary access, making the code more flexible for future object types.

- **Added helper methods**: Introduced `_add_player()` and `_add_asset()` methods to encapsulate the registration logic (holding strong references and adding to appropriate groups).

- **Added `AddAsset` event**: Created a new event type to support adding assets to the game, mirroring the existing `AddPlayer` event pattern.

- **Updated tests**: Modified test assertions to check group membership via `group.children()` instead of direct dictionary access, and added a new test for group nesting behavior.

## Notable Implementation Details

- Objects are now accessed through `env.loggers` (the global logger registry) rather than game-specific dictionaries, promoting a more decoupled architecture.
- The `_owned` set maintains strong references to prevent garbage collection, while the actual object access goes through groups and the environment's logger registry.
- The group nesting structure (`ALL` → `{ALL_PLAYERS, ALL_ASSETS}`) allows for efficient querying of all game objects or specific categories.

https://claude.ai/code/session_01CkPWBpwn1Mtp7BSVXAHrrC